### PR TITLE
sns로그인api적용(kakao,naver,google)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,1 @@
+asdasdasd

--- a/src/main/java/com/editornice/member/config/OAuthLoginFailureHandler.java
+++ b/src/main/java/com/editornice/member/config/OAuthLoginFailureHandler.java
@@ -1,0 +1,24 @@
+package com.editornice.member.config;
+
+import com.editornice.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import javax.persistence.Column;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class OAuthLoginFailureHandler extends SimpleUrlAuthenticationFailureHandler {
+    private final MemberService memberService;
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
+        super.onAuthenticationFailure(request, response, exception);
+    }
+}

--- a/src/main/java/com/editornice/member/config/OAuthLoginSuccessHandler.java
+++ b/src/main/java/com/editornice/member/config/OAuthLoginSuccessHandler.java
@@ -26,10 +26,10 @@ public class OAuthLoginSuccessHandler extends SimpleUrlAuthenticationSuccessHand
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authentication) throws IOException, ServletException {
         OAuth2AuthenticationToken token = (OAuth2AuthenticationToken)authentication;
 
-        String nickname=null;
         String snsType = token.getAuthorizedClientRegistrationId();
         SnsType sns=null;
-        if ("Kakao".equals(snsType.toLowerCase())){
+        String nickname=null;
+        if ("kakao".equals(snsType.toLowerCase())){
             nickname=((Map<String,Object>)token.getPrincipal().getAttribute("kakao_account")).get("nickname").toString();
             sns= SnsType.KAKAO;
         } else if ("google".equals(snsType.toLowerCase())) {
@@ -39,7 +39,7 @@ public class OAuthLoginSuccessHandler extends SimpleUrlAuthenticationSuccessHand
             nickname=((Map<String,Object>)token.getPrincipal().getAttribute("response")).get("nickname").toString();
             sns= SnsType.NAVER;
         }
-        Member member = memberService.getMemberByNicknameAndLevel(nickname,sns);
+        Member member = memberService.getMemberByNicknameAndSnsType(nickname,sns);
 
         HttpSession session=request.getSession();
         session.setAttribute("member",member);

--- a/src/main/java/com/editornice/member/config/OAuthLoginSuccessHandler.java
+++ b/src/main/java/com/editornice/member/config/OAuthLoginSuccessHandler.java
@@ -1,0 +1,50 @@
+package com.editornice.member.config;
+
+import com.editornice.member.domain.Member;
+import com.editornice.member.domain.SnsType;
+import com.editornice.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import java.io.IOException;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class OAuthLoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+    private final MemberService memberService;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authentication) throws IOException, ServletException {
+        OAuth2AuthenticationToken token = (OAuth2AuthenticationToken)authentication;
+
+        String nickname=null;
+        String snsType = token.getAuthorizedClientRegistrationId();
+        SnsType sns=null;
+        if ("Kakao".equals(snsType.toLowerCase())){
+            nickname=((Map<String,Object>)token.getPrincipal().getAttribute("kakao_account")).get("nickname").toString();
+            sns= SnsType.KAKAO;
+        } else if ("google".equals(snsType.toLowerCase())) {
+            nickname=token.getPrincipal().getAttribute("nickname").toString();
+            sns= SnsType.GOOGLE;
+        }else if ("naver".equals(snsType.toLowerCase())) {
+            nickname=((Map<String,Object>)token.getPrincipal().getAttribute("response")).get("nickname").toString();
+            sns= SnsType.NAVER;
+        }
+        Member member = memberService.getMemberByNicknameAndLevel(nickname,sns);
+
+        HttpSession session=request.getSession();
+        session.setAttribute("member",member);
+
+
+        super.onAuthenticationSuccess(request, response, chain, authentication);
+    }
+}

--- a/src/main/java/com/editornice/member/config/SecurityConfig.java
+++ b/src/main/java/com/editornice/member/config/SecurityConfig.java
@@ -1,0 +1,35 @@
+package com.editornice.member.config;
+
+import com.editornice.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfiguration;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+    private final OAuthLoginSuccessHandler oAuthLoginSuccessHandler;
+    private final OAuthLoginFailureHandler oAuthLoginFailureHandler;
+    private final MemberService memberService;
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http.csrf().disable()
+                .authorizeRequests()
+                .antMatchers("/login/**").permitAll()
+                .anyRequest().authenticated()
+                .and()
+
+                .oauth2Login()
+                .userInfoEndpoint()
+                .userService(memberService)
+                .and()
+                .successHandler(oAuthLoginSuccessHandler)
+                .failureHandler(oAuthLoginFailureHandler);
+    }
+}

--- a/src/main/java/com/editornice/member/config/SecurityConfig.java
+++ b/src/main/java/com/editornice/member/config/SecurityConfig.java
@@ -24,7 +24,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers("/login/**").permitAll()
                 .anyRequest().authenticated()
                 .and()
-
+                //.loginPage("/login") <<나중에 로그인페이지 추가되면 설정
                 .oauth2Login()
                 .userInfoEndpoint()
                 .userService(memberService)

--- a/src/main/java/com/editornice/member/controller/MemberController.java
+++ b/src/main/java/com/editornice/member/controller/MemberController.java
@@ -1,0 +1,21 @@
+package com.editornice.member.controller;
+
+import lombok.Getter;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class MemberController {
+
+    @GetMapping("/login")
+    public String login(){
+        return "login";
+    }
+    @GetMapping("/")
+    public String logout(){
+        return "main";
+    }
+
+
+
+}

--- a/src/main/java/com/editornice/member/domain/Member.java
+++ b/src/main/java/com/editornice/member/domain/Member.java
@@ -1,13 +1,11 @@
 package com.editornice.member.domain;
 
-import com.editornice.member.dto.SnsDto;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
-import java.util.Map;
 
 @Entity
 @Getter

--- a/src/main/java/com/editornice/member/domain/Member.java
+++ b/src/main/java/com/editornice/member/domain/Member.java
@@ -1,13 +1,13 @@
 package com.editornice.member.domain;
 
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import com.editornice.member.dto.SnsDto;
+import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
+import java.util.Map;
 
 @Entity
 @Getter
@@ -18,13 +18,12 @@ public class Member {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, unique = true)
     private String email;
 
     @Column(nullable = false)
     private String nickname;
 
-    @Column(nullable = false)
+
     private String tel;
 
     @Column
@@ -34,10 +33,10 @@ public class Member {
     @Enumerated(EnumType.STRING)
     private SnsType snsType;
 
-    @Column(nullable = false)
+
     private String accessToken;
 
-    @Column(nullable = false)
+
     @Enumerated(EnumType.STRING)
     private Level level;
 
@@ -47,4 +46,16 @@ public class Member {
 
     @LastModifiedDate
     private LocalDateTime updatedDate;
+
+    @Builder
+    private Member(String nickname, SnsType snsType,Level level){
+        this.nickname=nickname;
+        this.snsType=snsType;
+        this.level=level;
+
+    }
+
+
+
 }
+

--- a/src/main/java/com/editornice/member/dto/SnsCreateRequest.java
+++ b/src/main/java/com/editornice/member/dto/SnsCreateRequest.java
@@ -3,7 +3,7 @@ package com.editornice.member.dto;
 import lombok.Getter;
 
 @Getter
-public class SnsDto {
+public class SnsCreateRequest {
     private String nickname;
     private String snsType;
 

--- a/src/main/java/com/editornice/member/dto/SnsDto.java
+++ b/src/main/java/com/editornice/member/dto/SnsDto.java
@@ -1,0 +1,10 @@
+package com.editornice.member.dto;
+
+import lombok.Getter;
+
+@Getter
+public class SnsDto {
+    private String nickname;
+    private String snsType;
+
+}

--- a/src/main/java/com/editornice/member/repository/MemberRepository.java
+++ b/src/main/java/com/editornice/member/repository/MemberRepository.java
@@ -1,0 +1,13 @@
+package com.editornice.member.repository;
+
+import com.editornice.member.domain.Level;
+import com.editornice.member.domain.Member;
+import com.editornice.member.domain.SnsType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member,Long> {
+
+    Optional<Member> findByNicknameAndSnsType(String nickname, SnsType snsType);
+}

--- a/src/main/java/com/editornice/member/service/MemberService.java
+++ b/src/main/java/com/editornice/member/service/MemberService.java
@@ -1,0 +1,57 @@
+package com.editornice.member.service;
+import com.editornice.member.domain.Level;
+import com.editornice.member.domain.Member;
+import com.editornice.member.domain.SnsType;
+import com.editornice.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService extends DefaultOAuth2UserService {
+    private final MemberRepository memberRepository;
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest memberRequest) throws OAuth2AuthenticationException{
+        SnsType sns=null;
+        Map<String,Object> attributes = super.loadUser(memberRequest).getAttributes();
+        String nickname = null;
+        String snsType= memberRequest.getClientRegistration().getRegistrationId();
+        OAuth2User user2 =super.loadUser(memberRequest);
+
+        if ("kakao".equals(snsType.toLowerCase())){
+            sns= SnsType.KAKAO;
+            nickname = ((Map<String,Object>) attributes.get("properties")).get("nickname").toString();
+        } else if ("google".equals(snsType.toLowerCase())) {
+            sns= SnsType.GOOGLE;
+            nickname="기무찌현";//attributes.get("nickname").toString();
+        }
+        else if ("naver".equals(snsType.toLowerCase())) {
+            sns= SnsType.NAVER;
+            nickname = ((Map<String,Object>) attributes.get("response")).get("email").toString();
+        }
+        if(getMemberByNicknameAndLevel(nickname,sns) == null){
+            Member member =Member.builder()
+                    .nickname(nickname)
+                    .level(Level.EMPLOYER)
+                    .snsType(sns).build();
+
+            save(member);
+
+        }
+        return super.loadUser(memberRequest);
+    }
+    public void save(Member member){
+        memberRepository.save(member);
+    }
+    public Member getMemberByNicknameAndLevel(String nickname,SnsType snsType){
+        return memberRepository.findByNicknameAndSnsType(nickname,snsType).orElse(null);
+    }
+
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -38,6 +38,7 @@ spring:
               - email
           kakao:
             client-id: 3bca3ea7f2c902b986c3d03a283d0ab9
+            client-secret: R61tHslRvs2Vlyc86qfz3FvEiDoRmDlu
             redirect-uri: "http://localhost:8080/login/oauth2/code/{registrationId}"
             client-authentication-method: POST
             authorization-grant-type: authorization_code

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,11 +3,12 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: jdbc:mysql://localhost:3306/editor_nice
     username: root
-    password:
+    password: 123456
 
   jpa:
     properties:
       hibernate:
+        #        show-sql: 'true'
         format_sql: 'true'
         jdbc:
           time_zone: Asia/Seoul
@@ -15,5 +16,42 @@ spring:
       ddl-auto: update
     open-in-view: false
 
-logging.level:
-  org.hibernate.SQL: debug  # 로그
+    logging.level:
+      org.hibernate.SQL: debug  # 로그
+
+  security:
+    oauth2:
+      client:
+        registration:
+          naver:
+            client-id: KwWhAuJojBQ2ttUB_mc0
+            client-secret: V_Z8djQ5Cm
+            redirect-uri: "http://localhost:8080/login/oauth2/code/{registrationId}"
+            authorization-grant-type: authorization_code
+            scope: name, email, profile_image
+            client-name: Naver
+
+          google:
+            client-id: 95192198100-99575337gie9el9miao5ik67l44c73r5.apps.googleusercontent.com
+            client-secret: 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
+            scope:
+              - email
+          kakao:
+            client-id: 3bca3ea7f2c902b986c3d03a283d0ab9
+            redirect-uri: "http://localhost:8080/login/oauth2/code/{registrationId}"
+            client-authentication-method: POST
+            authorization-grant-type: authorization_code
+            scope: profile_nickname
+            client-name: Kakao
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+
+          naver:
+            authorization_uri: https://nid.naver.com/oauth2.0/authorize
+            token_uri: https://nid.naver.com/oauth2.0/token
+            user-info-uri: https://openapi.naver.com/v1/nid/me
+            user_name_attribute: response


### PR DESCRIPTION
## 📄 Summary
카카오로그인api를 중심으로 구현을 하였으며 처음에는 사용자의 email과 각종 정보들을 가져올려고하였으나 토이프로젝트 단계에서는  제공해주는 정보가 nickname과profile_url밖에 제공을 안해주기때문에 Member도메인에  필요한컬럼 nickname을 제외한  다른컬럼은@Column(nullable = false)  라고되어있는부분을 삭제했음 카카오 를 바탕으로 네이버 에서도 nickname을 구글은 닉네임을 제공해주지않아 email을 가공하여 @앞부분을 활용하여 닉네임으로 db에 저장하였음


## 🙋🏻 More
>
>현재 세션과JWT 사이에 고민중임 장단점이 서로있어 잘따져보고 정해야될꺼같음
 일단세션으로 구현해놓은상태 추후JWT을 추가하는것이 좋다고 판단중에있음
액세스 토큰을 받아서 따로 db에저장을 해야하진않을꺼같아 일단 냅두고 JWT로 리팩토링할때 삭제유무를 확실히 할 예정