### PR TITLE
공용 예외 구현

### DIFF
--- a/src/main/java/com/editornice/company/dto/request/CompanyCreateRequest.java
+++ b/src/main/java/com/editornice/company/dto/request/CompanyCreateRequest.java
@@ -3,6 +3,7 @@ package com.editornice.company.dto.request;
 import com.editornice.company.domain.Company;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import javax.validation.constraints.NotBlank;
@@ -11,6 +12,7 @@ import java.time.LocalDate;
 
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor
 public class CompanyCreateRequest {
 
     @NotBlank(message = "회사명을 입력해주세요.")
@@ -26,7 +28,7 @@ public class CompanyCreateRequest {
     private String address;
 
     @NotNull(message = "개업일자를 입력해주세요.")
-    @DateTimeFormat(pattern = "yyyyMMdd")
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
     private LocalDate openingDate;
 
     public Company toEntity() {

--- a/src/main/java/com/editornice/employer/service/EmployerService.java
+++ b/src/main/java/com/editornice/employer/service/EmployerService.java
@@ -3,9 +3,12 @@ package com.editornice.employer.service;
 import com.editornice.employer.domain.Employer;
 import com.editornice.employer.dto.response.EmployerCompanyResponse;
 import com.editornice.employer.repository.EmployerRepository;
+import com.editornice.global.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import static com.editornice.global.exception.ErrorCode.*;
 
 @Service
 @RequiredArgsConstructor
@@ -16,9 +19,9 @@ public class EmployerService {
 
     @Transactional(readOnly = true)
     public EmployerCompanyResponse getEmployerCompany(Long employerId) {
-        // TODO : 추후 예외 변경
+
         Employer employer = employerRepository.findById(employerId)
-                .orElseThrow(() -> new RuntimeException("존재하지 않는 구인자입니다."));
+                .orElseThrow(() -> new NotFoundException(NOT_FOUND_EMPLOYER_ID));
 
         if (employer.getCompany() == null) {
             throw new RuntimeException("등록된 업체가 존재하지 않습니다.");

--- a/src/main/java/com/editornice/global/exception/AuthException.java
+++ b/src/main/java/com/editornice/global/exception/AuthException.java
@@ -1,0 +1,14 @@
+package com.editornice.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class AuthException extends RuntimeException {
+    private final int code;
+    private final String message;
+
+    public AuthException(final ErrorCode errorCode) {
+        this.code = errorCode.getCode();
+        this.message = errorCode.getMessage();
+    }
+}

--- a/src/main/java/com/editornice/global/exception/ErrorCode.java
+++ b/src/main/java/com/editornice/global/exception/ErrorCode.java
@@ -1,7 +1,6 @@
 package com.editornice.global.exception;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Getter
 public enum ErrorCode {
@@ -9,8 +8,11 @@ public enum ErrorCode {
     /**
      * TODO : 예외 코드와 메세지에 대한 규칙 정해야 됨
      */
+    INVALID_REQUEST(1000, "잘못된 요청입니다."),
+    SERVER_ERROR(9999, "서버에 문제가 발생하였습니다."),
     NOT_FOUND_MEMBER_ID(4001, "해당 멤버는 존재하지 않습니다."),
     NOT_FOUND_EMPLOYER_ID(4002, "해당 구인자는 존재하지 않습니다.");
+
 
     private final int code;
     private final String message;

--- a/src/main/java/com/editornice/global/exception/ErrorCode.java
+++ b/src/main/java/com/editornice/global/exception/ErrorCode.java
@@ -1,0 +1,22 @@
+package com.editornice.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+public enum ErrorCode {
+
+    /**
+     * TODO : 예외 코드와 메세지에 대한 규칙 정해야 됨
+     */
+    NOT_FOUND_MEMBER_ID(4001, "해당 멤버는 존재하지 않습니다."),
+    NOT_FOUND_EMPLOYER_ID(4002, "해당 구인자는 존재하지 않습니다.");
+
+    private final int code;
+    private final String message;
+
+    ErrorCode(int code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/editornice/global/exception/ErrorResponse.java
+++ b/src/main/java/com/editornice/global/exception/ErrorResponse.java
@@ -1,0 +1,15 @@
+package com.editornice.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ErrorResponse {
+
+    private int code;
+    private String message;
+
+    public ErrorResponse(int code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/editornice/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/editornice/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,62 @@
+package com.editornice.global.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.util.Objects;
+
+import static com.editornice.global.exception.ErrorCode.INVALID_REQUEST;
+import static com.editornice.global.exception.ErrorCode.SERVER_ERROR;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    /**
+     * @Valid 애노테이션으로 검증에 실패한 경우 발생
+     */
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException e,
+            HttpHeaders headers,
+            HttpStatus status,
+            WebRequest request
+    ) {
+        log.warn(e.getMessage(), e);
+
+        String errMessage = Objects.requireNonNull(e.getBindingResult().getFieldError()).getDefaultMessage();
+        return ResponseEntity.badRequest()
+                .body(new ErrorResponse(INVALID_REQUEST.getCode(), errMessage));
+    }
+
+    @ExceptionHandler(NotFoundException.class)
+    protected ResponseEntity<ErrorResponse> handleNotFoundException(NotFoundException e) {
+        log.warn(e.getMessage(), e);
+
+        return ResponseEntity.badRequest()
+                .body(new ErrorResponse(e.getCode(), e.getMessage()));
+    }
+
+    @ExceptionHandler(AuthException.class)
+    protected ResponseEntity<ErrorResponse> handleAuthException(AuthException e) {
+        log.warn(e.getMessage(), e);
+
+        return ResponseEntity.badRequest()
+                .body(new ErrorResponse(e.getCode(), e.getMessage()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ErrorResponse> handleAuthException(Exception e) {
+        log.error(e.getMessage(), e);
+
+        return ResponseEntity.badRequest()
+                .body(new ErrorResponse(SERVER_ERROR.getCode(), "server error"));
+    }
+}

--- a/src/main/java/com/editornice/global/exception/NotFoundException.java
+++ b/src/main/java/com/editornice/global/exception/NotFoundException.java
@@ -1,0 +1,14 @@
+package com.editornice.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class NotFoundException extends RuntimeException {
+    private final int code;
+    private final String message;
+
+    public NotFoundException(final ErrorCode errorCode) {
+        this.code = errorCode.getCode();
+        this.message = errorCode.getMessage();
+    }
+}

--- a/src/test/java/com/editornice/employer/service/EmployerServiceTest.java
+++ b/src/test/java/com/editornice/employer/service/EmployerServiceTest.java
@@ -1,10 +1,15 @@
 package com.editornice.employer.service;
 
+import com.editornice.global.exception.ErrorCode;
+import com.editornice.global.exception.NotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.transaction.annotation.Transactional;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
@@ -14,5 +19,14 @@ class EmployerServiceTest {
 
     @Autowired
     private EmployerService employerService;
+
+    @Test
+    @DisplayName("존재하지 않는 employerId를 입력받으면 예외가 발생한다.")
+    void getEmployerCompany_NOT_FOUND_EMPLOYER_ID() {
+        // then
+        assertThatThrownBy(() -> employerService.getEmployerCompany(100L))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessageContaining(ErrorCode.NOT_FOUND_EMPLOYER_ID.getMessage());
+    }
 
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -14,5 +14,43 @@ spring:
       ddl-auto: create-drop
     open-in-view: false
 
-logging.level:
-  org.hibernate.SQL: debug  # 로그
+  logging.level:
+    org.hibernate.SQL: debug  # 로그
+
+  security:
+    oauth2:
+      client:
+        registration:
+          naver:
+            client-id: KwWhAuJojBQ2ttUB_mc0
+            client-secret: V_Z8djQ5Cm
+            redirect-uri: "http://localhost:8080/login/oauth2/code/{registrationId}"
+            authorization-grant-type: authorization_code
+            scope: name, email, profile_image
+            client-name: Naver
+
+          google:
+            client-id: 95192198100-99575337gie9el9miao5ik67l44c73r5.apps.googleusercontent.com
+            client-secret: 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
+            scope:
+              - email
+          kakao:
+            client-id: 3bca3ea7f2c902b986c3d03a283d0ab9
+            client-secret: R61tHslRvs2Vlyc86qfz3FvEiDoRmDlu
+            redirect-uri: "http://localhost:8080/login/oauth2/code/{registrationId}"
+            client-authentication-method: POST
+            authorization-grant-type: authorization_code
+            scope: profile_nickname
+            client-name: Kakao
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+
+          naver:
+            authorization_uri: https://nid.naver.com/oauth2.0/authorize
+            token_uri: https://nid.naver.com/oauth2.0/token
+            user-info-uri: https://openapi.naver.com/v1/nid/me
+            user_name_attribute: response


### PR DESCRIPTION
## 📄 Summary
> 공용 예외 구현했습니다.
일단은 요청한 데이터가 없는 경우인 NotFoundException과
 인증과 관련된 문제인 경우인 AuthException 두 개 만들어줬습니다.
이 두개의 범주를 벗어나는 예외가 생기면 새로 클래스 만드시면 됩니다.

사용 예시
```java
Employer employer = employerRepository.findById(employerId)
        .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_EMPLOYER_ID)); // ErrorCode는 import static으로 생략해주세요
```

큰 범위에서 예외 클래스인 NotFoundException를 쓰시고
작은 범위에서 인자값으로 ErrorCode 쓰시면 됩니다.
상황에 맞는 ErrorCode가 없다면 직접 만드시면 됩니다.


## 🙋🏻 More
> ErrorCode의 code와 메세지의 규칙을 같이 정해야 될 거 같습니다.
> 테스트 오류나서 test.application.yml에도 oauth 설정해줬습니다

#7 